### PR TITLE
Fix transfer out in mgmt save playerlist

### DIFF
--- a/backend/kbsb/interclubs/__init__.py
+++ b/backend/kbsb/interclubs/__init__.py
@@ -39,6 +39,7 @@ from .md_interclubs import (  # noqa F401
     ICVenueDB,
     ICVenueIn,
     PlayerlistNature,
+    PlayerPeriod,
     PLAYERSPERDIVISION,
 )
 

--- a/backend/kbsb/interclubs/icclubs.py
+++ b/backend/kbsb/interclubs/icclubs.py
@@ -24,6 +24,7 @@ from kbsb.interclubs import (
     DbICClub2425,
     DbICSeries,
     PlayerlistNature,
+    PlayerPeriod,
     load_icdata,
 )
 from kbsb.interclubs.registrations import find_icregistration
@@ -317,6 +318,7 @@ async def mgmt_updateICplayers(idclub: int, pi: ICPlayerUpdate) -> None:
     transferdeletes = []
     oldplsix = {p.idnumber: p for p in icc.players}
     newplsix = {p.idnumber: p for p in players}
+    period = PlayerPeriod.SEPTEMBER
     for p in newplsix.values():
         idn = p.idnumber
         if idn not in oldplsix:
@@ -360,7 +362,7 @@ async def mgmt_updateICplayers(idclub: int, pi: ICPlayerUpdate) -> None:
                     last_name=t.last_name,
                     natrating=t.natrating,
                     nature=PlayerlistNature.IMPORTED,
-                    period=period,
+                    period=t.period,
                     titular=None,
                 )
             )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kbsb"
-version = "3.4.0"
+version = "3.4.1"
 description = "API Website FRBE-KBSB-KSB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kbsb"
-version = "3.4.1"
+version = "3.4.2"
 description = "API Website FRBE-KBSB-KSB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kbsb"
-version = "3.4.2"
+version = "3.4.3"
 description = "API Website FRBE-KBSB-KSB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kbsb"
-version = "3.4.0"
+version = "3.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiocsv" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -746,7 +746,7 @@ wheels = [
 
 [[package]]
 name = "kbsb"
-version = "3.4.1"
+version = "3.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiocsv" },

--- a/frontend/pages/mgmt/interclubs.vue
+++ b/frontend/pages/mgmt/interclubs.vue
@@ -205,7 +205,7 @@ onMounted(async () => {
 
 <template>
   <VContainer>
-    <h1>Interclubs Manager 2024-25</h1>
+    <h1>Interclubs Manager 2025-26</h1>
     <v-dialog width="10em" v-model="waitingdialog">
       <v-card>
         <v-card-title>Loading...</v-card-title>

--- a/frontend/pages/tools/interclub_protected.vue
+++ b/frontend/pages/tools/interclub_protected.vue
@@ -201,7 +201,8 @@ async function selectClub() {
 
 onMounted(async () => {
   console.log("mounted")
-  // locale.value = l ? l : "nl"
+  let l = route.query.locale
+  locale.value = l ? l : "nl"
   checkAuth()
   await processICdata()
   getClubs()

--- a/shared/cloud/data/ic2526.yml
+++ b/shared/cloud/data/ic2526.yml
@@ -47,7 +47,7 @@ notrated_elo:
 playerlist_data:
   - period: september
     start: 2025-08-04
-    end: 2025-09-15
+    end: 2025-09-17
   - period: november
     start: 2025-11-01
     end: 2025-11-15


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-route language selection: the interface now picks the locale from the URL (e.g., ?locale=nl), defaulting to Dutch when absent.

- Bug Fixes
  - Corrected player transfer handling to use each player’s specific period.
  - Updated September period end date to reflect the accurate schedule.

- Style
  - Updated page header to “Interclubs Manager 2025-26”.

- Chores
  - Bumped backend project version to 3.4.3.
  - Made an internal type available across the interclubs module (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->